### PR TITLE
PAE-425 - Requesting the OAuth token to make authenticated requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ The configuration file must be in json format. e.g.
 
     {
         "LMS_URL": "path-to-lms-running-server",
-        "OPEN_EDX_OAUTH_TOKEN": "oAuth-lms-token",
+        "OPEN_EDX_OAUTH_CLIENT_ID": "client_id",
+        "OPEN_EDX_OAUTH_CLIENT_SECRET": "client_secret",
+        "OPEN_EDX_OAUTH_TOKEN_URL": "/oauth2/access_token/",
         "AWS_ACCESS_KEY_ID": "S3-AWS-access-key",
         "AWS_SECRET_ACCESS_KEY": "S3-AWS-secret-key",
         "SUPPORTED_REPORTS": [

--- a/proversity_reports_script/get_settings.py
+++ b/proversity_reports_script/get_settings.py
@@ -28,7 +28,7 @@ def get_settings(should_set_environment_settings):
         if should_set_environment_settings:
             set_environment_settings(settings)
     except ValueError as json_error:
-        print(json_error.message)
+        print(json_error)
         quit()
 
     return settings

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ requests==2.21.0
 boto3==1.9.138
 google-auth-oauthlib==0.3.0
 google-api-python-client==1.7.9
+oauthlib
+requests_oauthlib


### PR DESCRIPTION
## Description:

This RP adds the ability to request an OAuth token from the edx-platform's OAuth API to make authenticated requests and use the full oAuth pipeline.

## Configuration:

This setting is no longer used: OPEN_EDX_OAUTH_TOKEN.
These settings were added and are now required, otherwise it will fail:
"OPEN_EDX_OAUTH_CLIENT_ID": "client_id",
"OPEN_EDX_OAUTH_CLIENT_SECRET": "client_secret",
"OPEN_EDX_OAUTH_TOKEN_URL": "/oauth2/access_token/",

## Reviewers:

- [ ] @luismorenolopera 
- [x] @diegomillan 